### PR TITLE
Enable image upload in chat

### DIFF
--- a/src/app/api/files/[fileId]/route.ts
+++ b/src/app/api/files/[fileId]/route.ts
@@ -1,0 +1,15 @@
+import { openai } from "@/lib/openai";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ fileId: string }> }
+) {
+  const { fileId } = await params;
+  const file = await openai.files.retrieveContent(fileId);
+  const contentType = file.headers.get("content-type") || "application/octet-stream";
+  return new Response(file.body as unknown as ReadableStream, {
+    headers: { "Content-Type": contentType },
+  });
+}

--- a/src/app/api/threads/[threadId]/messages/route.ts
+++ b/src/app/api/threads/[threadId]/messages/route.ts
@@ -1,5 +1,9 @@
 import { assistantId } from "@/lib/assistant";
 import { openai } from "@/lib/openai";
+import fs from "fs";
+import { promises as fsPromises } from "fs";
+import { tmpdir } from "os";
+import path from "path";
 
 export const runtime = "nodejs";
 
@@ -9,14 +13,40 @@ export async function POST(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   { params }: any
 ) {
-  const { content } = await request.json();
   const { threadId } = await params;
 
-  console.log('content', content);
+  let content: Array<{ type: string; [key: string]: unknown }> = [];
+  const contentType = request.headers.get("content-type") || "";
+
+  if (contentType.includes("multipart/form-data")) {
+    const formData = await request.formData();
+    const text = formData.get("content") as string | null;
+    const file = formData.get("image") as File | null;
+    if (text) {
+      content.push({ type: "text", text });
+    }
+    if (file) {
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const tmpPath = path.join(tmpdir(), file.name);
+      await fsPromises.writeFile(tmpPath, buffer);
+      const uploaded = await openai.files.create({
+        file: fs.createReadStream(tmpPath),
+        purpose: "assistants",
+      });
+      content.push({
+        type: "image_file",
+        image_file: { file_id: uploaded.id },
+      });
+      await fsPromises.unlink(tmpPath);
+    }
+  } else {
+    const body = await request.json();
+    content = [{ type: "text", text: body.content }];
+  }
 
   await openai.beta.threads.messages.create(threadId, {
     role: "user",
-    content: content,
+    content,
   });
 
   const stream = openai.beta.threads.runs.stream(threadId, {


### PR DESCRIPTION
## Summary
- add `imageFile` input state and file picker in chat UI
- allow chat messages to upload images to API
- handle image uploads server-side and pass images to OpenAI
- add endpoint for retrieving uploaded files
- fix file route params

## Testing
- `npm run lint` *(fails: `next` not found)*
