### PR TITLE
Update create-build endpoint to use gpt-4.1

### DIFF
--- a/src/app/api/create-build/route.ts
+++ b/src/app/api/create-build/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: Request) {
     console.log('address', address);
 
     const { object: agentResponse } = await generateObject({
-      model: openai('gpt-4o'),
+      model: openai('gpt-4.1'),
       schema: buildSchema,
       mode: 'json',
       system: getSystemPrompt(),


### PR DESCRIPTION
## Summary
- switch `create-build` endpoint model from `gpt-4o` to `gpt-4.1`

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*