### PR TITLE
Add image generation to build creation

### DIFF
--- a/src/app/api/create-build/route.ts
+++ b/src/app/api/create-build/route.ts
@@ -105,6 +105,16 @@ export async function POST(request: Request) {
 
     console.log('agentResponse', validatedResponse);
 
+    // Generate an image based on the description
+    const image = await openaiSDK.images.generate({
+      prompt: description,
+      n: 1,
+      size: '1024x1024',
+      response_format: 'url',
+      model: 'dall-e-3',
+    });
+    const imageUrl = image.data?.[0]?.url ?? '';
+
     // Add the generated HTML to the thread
     await openaiSDK.beta.threads.messages.create(thread.id, {
       role: 'assistant',
@@ -118,6 +128,7 @@ export async function POST(request: Request) {
       model,
       address,
       thread_id: thread.id,
+      image: imageUrl,
     });
 
     return NextResponse.json({

--- a/src/components/build-list.tsx
+++ b/src/components/build-list.tsx
@@ -13,6 +13,7 @@ type Build = {
   html: string;
   created_at: string;
   model?: string; // Optional model field
+  image?: string;
 };
 
 export default function BuildList() {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -9,6 +9,7 @@ type Build = {
   thread_id: string;
   model: string;
   description: string;
+  image: string;
 };
 
 export const supabase = createClient(


### PR DESCRIPTION
## Summary
- generate an image with the build description in `create-build` API
- store the image URL in the `builds` table
- update types for builds to include the new `image` field

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`