### PR TITLE
Add share button on build page header

### DIFF
--- a/src/app/build/[id]/page.tsx
+++ b/src/app/build/[id]/page.tsx
@@ -1,5 +1,6 @@
 import BuildClient from '@/components/build-client';
 import DeleteBuildButton from '@/components/delete-build-button';
+import ShareBuildButton from '@/components/share-build-button';
 import { Button } from '@/components/ui/button';
 import { getBuild } from '@/lib/supabase';
 import { ChevronLeft } from 'lucide-react';
@@ -56,6 +57,7 @@ export default async function BuildPage({ params }: BuildPageProps) {
           >
             Publish
           </Button>
+          <ShareBuildButton id={id} title={build.title} />
           <DeleteBuildButton id={id} />
         </div>
       </header>

--- a/src/components/share-build-button.tsx
+++ b/src/components/share-build-button.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Share2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface ShareBuildButtonProps {
+  id: string;
+  title: string;
+}
+
+export default function ShareBuildButton({ id, title }: ShareBuildButtonProps) {
+  const handleShare = async () => {
+    const url = `${window.location.origin}/game/${id}`;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+      } catch {
+        // user might cancel share dialog
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(url);
+        toast.success('Link copied to clipboard');
+      } catch {
+        toast.error('Failed to copy link');
+      }
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="text-gray-400 hover:text-gray-200 cursor-pointer"
+      onClick={handleShare}
+    >
+      <Share2 className="h-4 w-4" />
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- allow sharing games from the build page
- insert ShareBuildButton in the build header

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`