### PR TITLE
Add farcaster username whitelist

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import Header from '@/components/header';
 import { FloatingBubbles } from '@/components/floating-bubbles';
 import { ChevronDown } from 'lucide-react';
 import { useLogin, usePrivy } from '@privy-io/react-auth';
+import WhitelistCheck from '@/components/whitelist-check';
 
 export default function Home() {
   const { ready, authenticated, user } = usePrivy();
@@ -140,10 +141,11 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-[#1a1a1a] text-white flex flex-col">
-      <Header />
-      <main className="flex-1 flex flex-col items-center pt-16 p-4">
-        <div className="w-full max-w-3xl">
+    <WhitelistCheck>
+      <div className="min-h-screen bg-[#1a1a1a] text-white flex flex-col">
+        <Header />
+        <main className="flex-1 flex flex-col items-center pt-16 p-4">
+          <div className="w-full max-w-3xl">
           <h1 className="text-3xl font-semibold text-center mb-8">
             What game are we building next?
           </h1>
@@ -209,5 +211,6 @@ export default function Home() {
         </div>
       </main>
     </div>
+    </WhitelistCheck>
   );
 }

--- a/src/components/whitelist-check.tsx
+++ b/src/components/whitelist-check.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { usePrivy } from '@privy-io/react-auth';
+import type { ReactNode } from 'react';
+import { isUserWhitelisted } from '@/lib/whitelist';
+
+interface WhitelistCheckProps {
+  children: ReactNode;
+}
+
+/**
+ * Gate component that only renders its children for whitelisted Farcaster users.
+ * Non-whitelisted users are asked to DM @hurls to request access.
+ */
+export default function WhitelistCheck({ children }: WhitelistCheckProps) {
+  const { authenticated, ready, user } = usePrivy();
+
+  if (!ready) {
+    return null;
+  }
+
+  if (authenticated && !isUserWhitelisted(user?.farcaster?.username)) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[#1a1a1a] text-white">
+        <p className="text-center">
+          You are not whitelisted. DM <span className="font-semibold">@hurls</span>{' '}
+          on Farcaster to be added.
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/lib/whitelist.ts
+++ b/src/lib/whitelist.ts
@@ -1,0 +1,15 @@
+/**
+ * Whitelist configuration for Farcaster usernames.
+ * Usernames are stored in lowercase to make comparison case-insensitive.
+ */
+export const WHITELISTED_USERNAMES = ['hurls'];
+
+/**
+ * Determine if a given username is included in the whitelist.
+ */
+export function isUserWhitelisted(username?: string | null): boolean {
+  if (!username) return false;
+  return WHITELISTED_USERNAMES.some(
+    (name) => name.toLowerCase() === username.toLowerCase()
+  );
+}


### PR DESCRIPTION
## Summary
- add whitelist util to manage allowed Farcaster usernames
- check whitelist status with `WhitelistCheck` component
- wrap home page in whitelist gate so non-whitelisted users are prompted to DM `@hurls`

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac98b7ec83319eef91cc0559af60