### PR TITLE
Add quick suggestion chips to chat

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -8,6 +8,7 @@ import { AssistantStreamEvent } from 'openai/resources/beta/assistants/assistant
 import { RequiredActionFunctionToolCall } from 'openai/resources/beta/threads/runs/runs';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import SuggestionChips from '@/components/suggestion-chips';
 import { toast } from 'sonner';
 
 type MessageApiResponse = {
@@ -75,6 +76,13 @@ const Chat = ({
     error: null,
   });
   const [inputDisabled, setInputDisabled] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const suggestions = [
+    'Change colors',
+    'Add more power-ups',
+    'Make it harder',
+  ];
 
   // Fetch existing messages when component mounts
   useEffect(() => {
@@ -365,10 +373,15 @@ const Chat = ({
         <Textarea
           value={userInput}
           onChange={(e) => setUserInput(e.target.value)}
+          onFocus={() => setShowSuggestions(true)}
+          onBlur={() => setShowSuggestions(false)}
           placeholder="What would you like to update?"
           className="flex-grow min-h-[48px] max-h-32 px-4 py-2 mr-2.5 rounded-md border-none bg-transparent text-[#c9d1d9] focus-visible:ring-0 focus-visible:ring-offset-0 resize-none placeholder:text-gray-400 disabled:opacity-60"
           disabled={inputDisabled}
         />
+        {showSuggestions && (
+          <SuggestionChips suggestions={suggestions} onSelect={setUserInput} />
+        )}
         <div className="flex justify-end">
           <Button
             type="submit"

--- a/src/components/suggestion-chips.tsx
+++ b/src/components/suggestion-chips.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+interface SuggestionChipsProps {
+  suggestions: string[];
+  onSelect: (suggestion: string) => void;
+}
+
+export default function SuggestionChips({ suggestions, onSelect }: SuggestionChipsProps) {
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {suggestions.map((suggestion) => (
+        <Button
+          key={suggestion}
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="rounded-full"
+          onClick={() => onSelect(suggestion)}
+        >
+          {suggestion}
+        </Button>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a `SuggestionChips` component for playful preset prompts
- show the chips when the chat textarea is focused

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686077489fd88331bc4395136906a9d7