### PR TITLE
Fix build context client setup

### DIFF
--- a/src/lib/build-context.tsx
+++ b/src/lib/build-context.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   createContext,
   useCallback,


### PR DESCRIPTION
## Summary
- mark BuildProvider as a client component

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861d73c456c8331bb3653c38b8e8d4e