### PR TITLE
Move docs to playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ ANALYTICS_ID=your_analytics_id
 
 ## 📖 Additional Documentation
 
-- [Creator Docs](/docs) - User guide for game creation and tokenization
+ - [Creator Playbook](/playbook) - User guide for game creation and tokenization
 - [AGENTS.md](./AGENTS.md) - Contributor guidelines and development standards
 - [CLAUDE.md](./CLAUDE.md) - AI assistant guidance for code modifications
 

--- a/src/app/build/[id]/page.tsx
+++ b/src/app/build/[id]/page.tsx
@@ -53,8 +53,8 @@ export default async function BuildPage({ params }: BuildPageProps) {
           </div>
 
           <div className="ml-auto flex items-center gap-2">
-            <Link href="/docs" className="mr-4 text-white hover:text-white">
-              Docs
+            <Link href="/playbook" className="mr-4 text-white hover:text-white">
+              Playbook
             </Link>
             <PublishButton buildId={id} />
           </div>

--- a/src/app/playbook/page.tsx
+++ b/src/app/playbook/page.tsx
@@ -1,7 +1,7 @@
 import Header from '@/components/header';
 
 export const metadata = {
-  title: 'Creator Docs - Mini Games Studio',
+  title: 'Creator Playbook - Mini Games Studio',
   description:
     'Learn how to create and publish mini games with optional tokens.',
 };

--- a/src/components/build-list.tsx
+++ b/src/components/build-list.tsx
@@ -116,7 +116,7 @@ export default function BuildList() {
           <p className="text-gray-300 mb-8 leading-relaxed">
             Before creating your first game, we recommend checking out our{' '}
             <Link
-              href="/docs"
+              href="/playbook"
               className="text-blue-400 hover:text-blue-300 underline font-semibold"
             >
               documentation

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -31,8 +31,8 @@ export default function Header() {
         <Link href="/create" className="text-gray-300 hover:text-gray-200">
           Create
         </Link>
-        <Link href="/docs" className="text-gray-300 hover:text-gray-200">
-          Docs
+        <Link href="/playbook" className="text-gray-300 hover:text-gray-200">
+          Playbook
         </Link>
         {authenticated ? (
           <DropdownMenu>


### PR DESCRIPTION
## Summary
- rename `/docs` route to `/playbook`
- update links to new route
- adjust page title to *Creator Playbook - Mini Games Studio*
- update README link

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804402ca008331af792543a1d60492