### PR TITLE
Update playbook content and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ ANALYTICS_ID=your_analytics_id
 
 ## 📖 Additional Documentation
 
-- [Creator Docs](/docs) - User guide for game creation and tokenization
+- [Creator Playbook](/playbook) - User guide for game creation and tokenization
 - [AGENTS.md](./AGENTS.md) - Contributor guidelines and development standards
 - [CLAUDE.md](./CLAUDE.md) - AI assistant guidance for code modifications
 

--- a/src/app/build/[id]/page.tsx
+++ b/src/app/build/[id]/page.tsx
@@ -53,8 +53,8 @@ export default async function BuildPage({ params }: BuildPageProps) {
           </div>
 
           <div className="ml-auto flex items-center gap-2">
-            <Link href="/docs" className="mr-4 text-white hover:text-white">
-              Docs
+            <Link href="/playbook" className="mr-4 text-white hover:text-white">
+              Playbook
             </Link>
             <PublishButton buildId={id} />
           </div>

--- a/src/app/playbook/page.tsx
+++ b/src/app/playbook/page.tsx
@@ -1,26 +1,34 @@
 import Header from '@/components/header';
 
 export const metadata = {
-  title: 'Creator Docs - Mini Games Studio',
+  title: 'Creator Playbook - Mini Games Studio',
   description:
-    'Learn how to create and publish mini games with optional tokens.',
+    'Learn how to create tokenized mini games and earn rewards.',
 };
 
 /**
  * Detailed documentation for creators building mini games.
  * Covers the workflow, AI models, prompting strategies, scoring and token mechanics.
  */
-export default function CreatorDocs() {
+export default function CreatorPlaybook() {
   return (
     <div className="min-h-screen bg-[#1a1a1a] text-white flex flex-col">
       <Header />
       <main className="flex-1 w-full max-w-3xl mx-auto p-6 space-y-8">
         <section>
-          <h1 className="text-3xl font-semibold mb-4">Game Creation Guide</h1>
+          <h1 className="text-3xl font-semibold mb-4">
+            Creator Playbook: Earn Money with Mini Games
+          </h1>
+          <p className="text-zinc-300 mb-2">
+            Use AI to generate fun game mechanics and assets in minutes.
+          </p>
+          <p className="text-zinc-300 mb-2">
+            Publishing a game automatically creates a token that rewards players
+            based on their scores.
+          </p>
           <p className="text-zinc-300">
-            Mini Games Studio lets you create tokenized games that run in
-            Farcaster. Understanding the constraints and token mechanics will
-            help you build successful games that players love.
+            Fund your reward pool by adding more tokens and keep an eye on the
+            balance to maintain engagement.
           </p>
         </section>
 

--- a/src/components/build-list.tsx
+++ b/src/components/build-list.tsx
@@ -116,10 +116,10 @@ export default function BuildList() {
           <p className="text-gray-300 mb-8 leading-relaxed">
             Before creating your first game, we recommend checking out our{' '}
             <Link
-              href="/docs"
+              href="/playbook"
               className="text-blue-400 hover:text-blue-300 underline font-semibold"
             >
-              documentation
+              playbook
             </Link>{' '}
             to understand best practices and get inspired by examples.
           </p>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -31,8 +31,8 @@ export default function Header() {
         <Link href="/create" className="text-gray-300 hover:text-gray-200">
           Create
         </Link>
-        <Link href="/docs" className="text-gray-300 hover:text-gray-200">
-          Docs
+        <Link href="/playbook" className="text-gray-300 hover:text-gray-200">
+          Playbook
         </Link>
         {authenticated ? (
           <DropdownMenu>


### PR DESCRIPTION
## Summary
- rename `/docs` route to `/playbook`
- highlight earning money in the playbook page with a new introduction
- update navigation links and text from Docs to Playbook
- refresh README link

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880441c03f48331a1e4cd87587fec2e